### PR TITLE
feat(UI): adds scrollbar on large env vars forms

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/css/style.css
+++ b/src/rockstor/storageadmin/static/storageadmin/css/style.css
@@ -522,6 +522,11 @@ table.tablesorter thead tr .headerSortDown {
   padding: 0 20px 20px 20px;
 }
 
+#install-rockon-overlay > .overlay-content {
+  overflow-y: auto;
+  max-height: 80vh;
+}
+
 #pool-quick-details {
   background: #fff;
 }


### PR DESCRIPTION
In case of a RockOn with many environment vars, the form will be very long. To the point that it will continue outside the viewport. I have set its max-height to 80vh, which will keep the form nice and short. But in the case of larger forms, it will keep the form within the viewport. In the latter case, a vertical scrollbar is added to allow for a nicer user experience.